### PR TITLE
keep basketball pitches with 1 hoop as generic

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/helpers/getPitchTypeFromTags.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/helpers/getPitchTypeFromTags.ts
@@ -12,6 +12,12 @@ export default function getPitchTypeFromTags(tags: Record<string, string>): Vect
 
 	for (const value of values) {
 		const type = lookup[value];
+		
+		if (type == 'basketball') {
+			if( getTagValues(tags, 'hoops')[0] == '1') {
+				return 'generic';
+			}
+		}
 
 		if (type !== undefined) {
 			return type;

--- a/src/lib/tile-processing/vector/qualifiers/factories/helpers/getPitchTypeFromTags.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/helpers/getPitchTypeFromTags.ts
@@ -12,11 +12,9 @@ export default function getPitchTypeFromTags(tags: Record<string, string>): Vect
 
 	for (const value of values) {
 		const type = lookup[value];
-		
-		if (type == 'basketball') {
-			if( getTagValues(tags, 'hoops')[0] == '1') {
-				return 'generic';
-			}
+
+		if (type === 'basketball' && getTagValues(tags, 'hoops')[0] == '1') {
+			return 'generic';
 		}
 
 		if (type !== undefined) {


### PR DESCRIPTION
1 hoop basketball pitches are usually strange shapes, and the texture doesn't fit them
(https://wiki.openstreetmap.org/wiki/Key:hoops)

before,after
![bitmap](https://user-images.githubusercontent.com/26939824/236340990-14797dd4-da43-4748-b668-1e771ade9d17.png)
