### PR TITLE
ignore roof:levels <= 0

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/helpers/getBuildingParamsFromTags.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/helpers/getBuildingParamsFromTags.ts
@@ -4,6 +4,7 @@ import getRoofOrientationFromOSMOrientation
 import {
 	parseDirection,
 	parseHeight,
+	parseRoofLevels,
 	readTagAsUnsignedFloat,
 	readTagAsUnsignedInt
 } from "~/lib/tile-processing/vector/qualifiers/factories/helpers/tagHelpers";
@@ -46,7 +47,7 @@ export default function getBuildingParamsFromTags(
 
 	const roofParams = getRoofParamsFromTags(tags);
 	const roofOrientation = getRoofOrientationFromOSMOrientation(tags['roof:orientation']);
-	const roofLevels = readTagAsUnsignedInt(tags, 'roof:levels') ?? getDefaultLevelsFromRoofType(roofParams.type);
+	const roofLevels = parseRoofLevels(tags, 'roof:levels') ?? getDefaultLevelsFromRoofType(roofParams.type);
 	const roofDirection = parseDirection(tags['roof:direction'], 0);
 	const roofAngle = readTagAsUnsignedFloat(tags, 'roof:angle');
 	let roofHeight = parseHeight(tags['roof:height'], roofLevels * levelHeight);

--- a/src/lib/tile-processing/vector/qualifiers/factories/helpers/tagHelpers.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/helpers/tagHelpers.ts
@@ -102,11 +102,12 @@ export function parseHeight(str: string = '', fallback?: number): number {
 
 export function parseRoofLevels(tags: Record<string, string>, key: string): number {
 	const levels = readTagAsUnsignedInt(tags, key);
-	if (levels <= 0) {
+
+	if (levels === undefined || levels <= 0) {
 		return undefined;
 	}
 	
-	return levels ?? undefined;
+	return levels;
 }
 
 export function parseDirection(str: string = '', fallback?: number): number {

--- a/src/lib/tile-processing/vector/qualifiers/factories/helpers/tagHelpers.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/helpers/tagHelpers.ts
@@ -100,6 +100,15 @@ export function parseHeight(str: string = '', fallback?: number): number {
 	return parseMeters(str) ?? fallback;
 }
 
+export function parseRoofLevels(tags: Record<string, string>, key: string): number {
+	const levels = readTagAsUnsignedInt(tags, key);
+	if (levels <= 0) {
+		return undefined;
+	}
+	
+	return levels ?? undefined;
+}
+
 export function parseDirection(str: string = '', fallback?: number): number {
 	const directions: Record<string, number> = {
 		N: 0,


### PR DESCRIPTION
before / after
![bitmap](https://user-images.githubusercontent.com/26939824/236957949-109466f1-5b5f-4b13-b5a0-9755822532c0.png)

https://streets.gl/#51.47805,0.01290,30.75,40.00,203.16 (not cached)
this is the same behaviour as f4map