### PR TITLE
also check `windows=*` for specifying if a building has windows

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/helpers/isBuildingHasWindows.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/helpers/isBuildingHasWindows.ts
@@ -11,16 +11,20 @@ const buildingsWithoutWindows: string[] = [
 	'service',
 	'digester',
 	'water_tower',
-	'shed'
+	'shed',
+	'ger',
+	'barn',
+	'slurry_tank',
+	'container'
 ];
 
 export default function isBuildingHasWindows(tags: Record<string, string>): boolean {
-	if (tags.window === 'yes') {
-		return true;
-	}
-
-	if (tags.window === 'no') {
+	if (tags.window === 'no' || tags.windows === 'no') {
 		return false;
+	}	
+	
+	if (tags.window === 'yes' || tags.windows === 'yes') {
+		return true;
 	}
 
 	if (


### PR DESCRIPTION
before/after
(building parts are all tagged `windows=no`)
![bitmap](https://user-images.githubusercontent.com/26939824/236962162-0c24d9fa-54c1-4d00-b615-870991f044c7.png)
https://www.streets.gl/#51.46842,0.00747,25.75,325.50,206.40


window=* is part of simple indoor mapping schema, and implies a single window (with a node and window=yes)
windows=* is more generic, is unused, and makes more sense.

It looks like people assumed this was the correct tag in the first place, the usage increase matches the release of streets-gl: [(link)](https://taginfo.openstreetmap.org/keys/windows#chronology)
![Screenshot from 2023-05-09 01-08-30](https://user-images.githubusercontent.com/26939824/236962521-4e1cda14-2eb6-4ebc-86f1-1aa4e0b59440.png)

Fixes offhand comment at end of https://github.com/StrandedKitty/streets-gl/issues/69#issuecomment-1538228725