### PR TITLE
use min_level when no level or height

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/helpers/getBuildingParamsFromTags.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/helpers/getBuildingParamsFromTags.ts
@@ -61,7 +61,7 @@ export default function getBuildingParamsFromTags(
 	}
 
 	if (height === null && levels === null) {
-		levels = fallbackLevels;
+		levels = (minLevel !== null) ? minLevel: fallbackLevels;
 		height = levels * levelHeight + roofHeight
 	} else if (height === null) {
 		height = levels * levelHeight + roofHeight


### PR DESCRIPTION
before/after
![bitmap](https://user-images.githubusercontent.com/26939824/236964979-695f7d24-171a-454f-b955-11a1a799b179.png)


fixes #25