### PR TITLE
render area:highway=footway

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/AreaQualifierFactory.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/AreaQualifierFactory.ts
@@ -153,6 +153,18 @@ export default class AreaQualifierFactory extends AbstractQualifierFactory<Vecto
 				}
 			}];
 		}
+		
+		if (
+			tags['area:highway'] === 'footway' ||
+			tags['area:highway'] === 'pedestrian'
+		) {
+			return [{
+				type: QualifierType.Descriptor,
+				data: {
+					type: 'pavement'
+				}
+			}];
+		}
 
 		if (tags.man_made === 'bridge') {
 			return [{


### PR DESCRIPTION
![bitmap-min](https://github.com/StrandedKitty/streets-gl/assets/26939824/abb8d428-628d-4f83-986f-609c750d65a5)
https://www.openstreetmap.org/way/372975520
https://www.openstreetmap.org/way/4483968

ideally all highway areas would be rendered, and it would use the surface=* tag to determine material. I can't figure out how to do that though .-.