### PR TITLE
Update bicycle parkings description in taginfo.json

### DIFF
--- a/docs/taginfo.json
+++ b/docs/taginfo.json
@@ -57,6 +57,66 @@
 			"description": ""
 		},
 		{
+			"key": "area:highway",
+			"value": "emergency",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "footway",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "motorway",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "pedestrian",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "primary",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "residential",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "secondary",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "service",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "tertiary",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "trunk",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "unclassified",
+			"description": ""
+		},
+		{
+			"key": "area:highway",
+			"value": "yes",
+			"description": ""
+		},
+		{
 			"key": "artwork_type",
 			"value": "sculpture",
 			"description": ""

--- a/docs/taginfo.json
+++ b/docs/taginfo.json
@@ -44,7 +44,7 @@
 		{
 			"key": "amenity",
 			"value": "bicycle_parking",
-			"description": ""
+			"description": "Bicycle parkings areas are mapped as paved areas."
 		},
 		{
 			"key": "amenity",


### PR DESCRIPTION
Added description for bicycle parking to make clear is only about areas, not nodes (I thought they were rendered with a little 3d model since they are mainly mapped as nodes so and took me a while to understand how they were used in the project)