### PR TITLE
Estimate tree height (part of #49)

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/NodeQualifierFactory.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/NodeQualifierFactory.ts
@@ -9,6 +9,7 @@ import {
 	parseHeight
 } from "~/lib/tile-processing/vector/qualifiers/factories/helpers/tagHelpers";
 import getTreeTypeFromTags from "~/lib/tile-processing/vector/qualifiers/factories/helpers/getTreeTypeFromTags";
+import getTreeHeight from "./helpers/getTreeHeight";
 
 export default class NodeQualifierFactory extends AbstractQualifierFactory<VectorNodeDescriptor> {
 	public fromTags(tags: Record<string, string>): Qualifier<VectorNodeDescriptor>[] {
@@ -21,7 +22,7 @@ export default class NodeQualifierFactory extends AbstractQualifierFactory<Vecto
 				type: QualifierType.Descriptor,
 				data: {
 					type: 'tree',
-					height: parseHeight(tags.height, undefined),
+					height: getTreeHeight(tags),
 					treeType: getTreeTypeFromTags(tags)
 				}
 			}];

--- a/src/lib/tile-processing/vector/qualifiers/factories/helpers/getTreeHeight.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/helpers/getTreeHeight.ts
@@ -1,0 +1,21 @@
+import { parseMeters } from "./tagHelpers";
+
+export default function getTreeHeight(tags: Record<string, string>): number | undefined {
+	const minHeight = parseMeters(tags['min_height']) || 0.0;
+	let height = (parseMeters(tags['height']) || parseMeters(tags['est_height'])) - minHeight;
+
+	if (!height) {
+		// estimate height from width
+		let width = parseMeters(tags['diameter_crown']);
+
+		// estimate width from trunk diameter / circumference
+		if (!width) {
+			const diameter = parseMeters(tags['diameter']) || parseMeters(tags['circumference']) / Math.PI;
+			width = diameter * 30.0;
+		}
+		
+		height = width * 2.0;
+	}
+
+	return height || undefined;
+}


### PR DESCRIPTION
Estimate tree height based on `est_height`, `crown_diameter`, `diameter` or `circumference` if `height` is not available.

Also, correctly subtract `min_height` from `height` or `est_height`.