### PR TITLE
handle roof levels <=0

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/vector-tile/helpers/getBuildingParams.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/vector-tile/helpers/getBuildingParams.ts
@@ -40,7 +40,7 @@ export default function getBuildingParams(
 
 	const roofParams = getRoofParams(tags);
 	const roofOrientation = getRoofOrientation(<string>tags['roofOrientation']);
-	const roofLevels = <number>tags.roofLevels ?? (roofParams.type === 'flat' ? 0 : 1);
+	const roofLevels = tags.roofLevels <= 0 ? 0.6 : <number>tags.roofLevels ?? (roofParams.type === 'flat' ? 0 : 1);
 	const roofDirection = <number>tags.roofDirection ?? null;
 	const roofAngle = <number>tags.roofAngle ?? null;
 	let roofHeight = <number>tags.roofHeight ?? (roofLevels * levelHeight);


### PR DESCRIPTION
`roof:levels=0` is used 780,443 times in OSM, and currently causes roofs to render flat when they shouldn't be. It's being used in OSM to mean that there isn't an easily accessible level in the roof, not that the roof has no height.

![bitmap](https://github.com/StrandedKitty/streets-gl/assets/26939824/eef9dcf9-bc6b-4a9d-b53e-c37aefbf6ee6)