### PR TITLE
Alter touch device check

### DIFF
--- a/src/app/systems/UISystem.ts
+++ b/src/app/systems/UISystem.ts
@@ -75,7 +75,7 @@ export default class UISystem extends System {
 	}
 
 	private detectMobile(): void {
-		if (Utils.isMobileBrowser() || navigator.maxTouchPoints) {
+		if (Utils.isMobileBrowser() || !window.matchMedia("(pointer: fine)").matches) {
 			alert('Mobile devices and touch devices are not supported. Please use a computer with a mouse and keyboard.');
 		}
 	}


### PR DESCRIPTION
In order to reduce false positives from devices with a proper pointer device (ie. a mouse) that also have touch support, I've replaced the maxTouchPoints check with a check if the client doesn't match the media query `(pointer: fine)`. As far as I can tell, and from testing, this should filter out platforms without a mouse as their primary pointer device, without catching devices with a mouse and keyboard that also have touch support.