### PR TITLE
Don't place busStop on a public_transport=stop_position

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/osm/OSMNodeQualifierFactory.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/osm/OSMNodeQualifierFactory.ts
@@ -96,7 +96,7 @@ export default class OSMNodeQualifierFactory extends AbstractQualifierFactory<Ve
 			}];
 		}
 
-		if (tags.highway === 'bus_stop') {
+		if (tags.highway === 'bus_stop' && !(tags['public_transport'] === 'stop_position')) {
 			return [{
 				type: QualifierType.Descriptor,
 				data: {


### PR DESCRIPTION
When a stop position on the road is tagged with `highway=bus_stop` + `public_transport=stop_position` there shouldn't be a bus stop shelter.