### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/src/app/ui/components/SelectionPanel/SelectionPanel.tsx
+++ b/src/app/ui/components/SelectionPanel/SelectionPanel.tsx
@@ -25,7 +25,7 @@ interface FeatureDescription {
 const getOSMURL = (type: FeatureType, id: number): string => {
 	const typeStr = type === FeatureType.Way ? 'way' : 'relation';
 
-	return `https://www.openstreetmap.org/api/0.6/${typeStr}/${id}.json`;
+	return `https://api.openstreetmap.org/api/0.6/${typeStr}/${id}.json`;
 }
 
 const getType = (tags: Record<string, string>): string => {


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)