### PR TITLE
better estimation of crown diameter

### DIFF
--- a/src/lib/tile-processing/vector/qualifiers/factories/osm/helpers/getTreeHeight.ts
+++ b/src/lib/tile-processing/vector/qualifiers/factories/osm/helpers/getTreeHeight.ts
@@ -11,7 +11,7 @@ export default function getTreeHeight(tags: Record<string, string>): number | un
 		// estimate width from trunk diameter / circumference
 		if (!width) {
 			const diameter = parseMeters(tags['diameter'], 0.001) || parseMeters(tags['circumference']) / Math.PI;
-			width = diameter * 30.0;
+			width = diameter * 23.0;
 		}
 
 		// check if width is reasonable


### PR DESCRIPTION
I have been looking at a dataset of 230000 street trees. The median of `crown diameter / trunk diameter` of that dataset is about `23.0` (well, in that dataset, it is 22.9872633189497), so it is a better default than `30.0`